### PR TITLE
thf/DTHFUI-1177 - Ferramenta para a migração das importações

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Command | Alias | Description
 --- | --- | ---
 *[add](#add)* | a | Add a module that has a dynamic component of your choice.
 *[new](#new)* | n | Creates a new project based in a template.
+*[convert-imports](#convert-imports)* | ci | Converts imports from THF version 3 to THF version 4.
 
 ```
 thf add <newComponentName>
@@ -46,6 +47,11 @@ thf add <newComponentName>
 
 ```
 thf new <projectName>
+```
+
+
+```
+thf convert-imports
 ```
 
 ### add
@@ -117,6 +123,24 @@ The informed value in this option will be used by the `thf-toolbar` title, if yo
 ```
 thf new <projectName> --title <title>
 ```
+
+### convert-imports
+
+New version of THF 4 has a new and easier way to import components. Now all you need is the project name.
+
+For example this:
+
+```
+import { ThfPageLogin } from '@totvs/thf-templates/components/thf-page-login';
+```
+
+Is now is changed to:
+
+```
+import { ThfPageLogin } from '@totvs/thf-templates';
+```
+
+Using this command in your project Angular or Ionic folder changes those imports automatically.
 
 ### Add Git remote repository
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,4 +30,15 @@ program
     command.add(moduleName);
   });
 
+program
+  .command('convert-imports')
+  .alias('ci')
+  .description('convert imports from THF 3 to THF 4')
+  .action(() => {
+    const path = process.cwd();
+    const srcPath = pathNode.join(path, 'src');
+
+    command.convertImports(srcPath);
+  });
+
 program.parse(process.argv);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 require('shelljs/global');
+const pathNode = require('path');
 
 const program = require('commander');
 const command = require('../src/commands');

--- a/src/commands/convertImports.js
+++ b/src/commands/convertImports.js
@@ -1,0 +1,39 @@
+const fileSystem = require('fs');
+
+function convertImports(srcPath) {
+
+  const files = fileSystem.readdirSync(directory);
+
+  for (let i=0; i < files.length; i++) {
+    // path.step recupera o separador específico do SO
+    const file = `${directory}${path.sep}${files[i]}`;
+
+    if((/(\.(gif|jpg|jpeg|tiff|png|ico|git))|(node_modules)$/i).test(file)) {
+      continue;
+    }
+
+    const stats = fileSystem.statSync(file);
+
+    if(stats.isFile()) {
+      convertFileImport(file);
+
+    } else if(stats.isDirectory()) {
+      convertDirectory(file);
+    }
+  }
+
+}
+
+function convertFileImport(file) {
+
+}
+
+function getFileSync(fileName) {
+  return JSON.parse(fileSystem.readFileSync(fileName, 'utf-8'));
+}
+
+function writeFileSync(fileName, data) {
+  fileSystem.writeFileSync(fileName, data);
+}
+
+module.exports = { convertImports };

--- a/src/commands/convertImports.js
+++ b/src/commands/convertImports.js
@@ -33,7 +33,7 @@ function convertFileImport(file) {
 
   const newLines = lines.map(line => {
     if (line.includes(importPrefix)) {
-      const regexResult = line.match(/('|")(@totvs\/thf-(ui|storage|templates|sync)\/(.*?))('|")/);
+      const regexResult = line.match(/('|")(@totvs\/thf-(ui|storage|kendo|code\-editor|templates|sync)\/(.*?))('|")/);
 
       if (regexResult) {
         const word = regexResult[2];

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,11 +1,13 @@
 const newCmd = require('./new');
 const addCmd = require('./add');
+const convertImportsCmd = require('./convertImports');
 
 class Commands {
-  constructor(addCommand, newCommand) {
+  constructor(addCommand, newCommand, convertImportsCommand) {
     this.add = addCommand;
     this.new = newCommand;
+    this.convertImports = convertImportsCommand;
   }
 }
 
-module.exports = new Commands(addCmd, newCmd);
+module.exports = new Commands(addCmd, newCmd, convertImportsCmd);


### PR DESCRIPTION
### Ferramenta para migrar as importações dos projetos

Agora com a nova versão, o usuário não necessita mais colocar o caminho completo das importações, somente o nome do projeto. Por exemplo:

`import { ThfModalComponent } from '@totvs/thf-ui';`

DTHFUI-1201 - Codificação

DTHFUI-1204 - Documentação

Para testar:

1 - Baixe este repositório
2 - Faça `npm i`
3 - Depois, ainda na pasta do repositório, execute o comando: `npm link`
4 - Entre em algum projeto que utilize THF e execute: `thf convert-imports`